### PR TITLE
feature/chat-room: Separated VITE_BASE_URL from VITE_SOCKET_BASE_URL

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -1,7 +1,7 @@
 import { io } from "socket.io-client";
 import { BASE_URL } from "./redux/constants";
 
-export const socket = io(BASE_URL, {
+export const socket = io(import.meta.env.VITE_SOCKET_BASE_URL ?? BASE_URL, {
   path: (import.meta.env.VITE_SOCKET_PATH ?? "") + "/socket.io",
   // transports: ['websocket', 'polling']
 });


### PR DESCRIPTION
Can be ignored in development env due to a nullish coalescing in socket config.